### PR TITLE
Fix issues with bundle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ $ bundle
 $ make app-cal
 ```
 
+If you have issues with bundle command, you have to install the Xcode Command Line Tools running this command:
+
+```
+$ xcode-select --install
+```
+
 
 #### Cucumber
 


### PR DESCRIPTION
The bundle command when you build a .app for the simulator doesn't work if you have not the Xcode Command Line Tools installed.